### PR TITLE
Docker compatibility and better URL handling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.gitignore
+.idea/
+.vscode/
+.cursor/
+.cursorindexingignore
+*.md
+prototipos/
+relatorios/

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,31 @@
+RewriteEngine On
+
+# Rule for handling HTML files (e.g., /carrinho.html -> /view/carrinho.html)
+# Only apply if the request is for a .html file
+RewriteCond %{REQUEST_URI} \.html$
+# And the requested file doesn't exist in the root
+RewriteCond %{REQUEST_FILENAME} !-f
+# And the file exists in the /view/ directory
+RewriteCond %{DOCUMENT_ROOT}/view/%{REQUEST_URI} -f
+RewriteRule ^(.+\.html)$ view/$1 [L]
+
+# Ensure that requests to / (root) are still handled by DirectoryIndex
+# This might not be strictly necessary if DirectoryIndex is already doing its job for the root.
+# RewriteCond %{REQUEST_URI} ^/$
+# RewriteRule ^$ view/home.html [L]
+
+# Rule for handling the root path explicitly if needed,
+# especially if DirectoryIndex doesn't cover all cases or if you want to be more explicit.
+# This ensures that accessing the base URL (e.g., http://localhost/) serves view/home.html.
+RewriteCond %{REQUEST_URI} ^/$
+RewriteCond %{DOCUMENT_ROOT}/view/home.html -f
+RewriteRule ^$ view/home.html [L]
+
+# If you also want to handle cases where users might type /view/ or /view/home.html explicitly
+# and you want to ensure consistency or redirect them, you could add rules for that,
+# but for now, let's focus on making the simple links work.
+
+# It's also good practice to prevent access to .htaccess itself
+<Files .htaccess>
+    Require all denied
+</Files> 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# Use an official PHP image with Apache
+FROM php:8.2-apache
+
+# Set working directory
+WORKDIR /var/www/html
+
+# Install system dependencies required for PHP extensions
+# libpq-dev: for pdo_pgsql
+# libzip-dev, unzip: for zip extension (good for Composer, general utility)
+# libpng-dev, libjpeg-dev, libfreetype6-dev: for gd extension
+RUN apt-get update && apt-get install -y \
+    libpq-dev \
+    libzip-dev \
+    unzip \
+    libpng-dev \
+    libjpeg-dev \
+    libfreetype6-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install PHP extensions
+# pdo & pdo_pgsql: for PostgreSQL database access
+# gd: for image manipulation (if needed)
+# zip: for handling zip files
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) pdo pdo_pgsql gd zip
+
+# Enable Apache rewrite module (commonly used for clean URLs)
+RUN a2enmod rewrite
+
+# Copy application files from the current directory (where Dockerfile is) to the container
+COPY . /var/www/html/
+
+# Configure Apache DirectoryIndex to serve view/home.html by default when accessing the root
+# Also, ensure AllowOverride All is set for the DocumentRoot to process .htaccess files
+RUN sed -i '/<Directory \/var\/www\/html>/a \    AllowOverride All' /etc/apache2/apache2.conf && \
+    sed -i '/DocumentRoot \/var\/www\/html/a \    DirectoryIndex view/home.html index.php index.html' /etc/apache2/sites-available/000-default.conf
+
+
+
+# Set permissions for Apache if necessary.
+# Apache runs as www-data. Session files and any upload/cache directories need to be writable.
+# The base image usually handles session path permissions.
+# If you have specific upload or cache directories, uncomment and modify the following:
+# RUN chown -R www-data:www-data /var/www/html/your-writable-directory
+# RUN chmod -R 775 /var/www/html/your-writable-directory
+
+# Application loads .env file. Ensure this file is provided at runtime.
+# A .env.example should be in your repository to guide users.
+
+# Expose port 80 for Apache
+EXPOSE 80
+
+# The base php:8.2-apache image already sets the CMD to apache2-foreground
+# CMD ["apache2-foreground"] 

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -1,1 +1,18 @@
-export const API_BASE = "http://localhost/bibliotech/api";
+// Get base URL dynamically based on current location
+const getBaseUrl = () => {
+  // Get the origin (protocol + hostname + port)
+  const origin = window.location.origin;
+  // Get pathname and find the position of "/bibliotech"
+  const pathname = window.location.pathname;
+  const bibliotechIndex = pathname.indexOf('/bibliotech');
+  
+  // If "/bibliotech" is in the path, use it in the API URL
+  if (bibliotechIndex !== -1) {
+    return `${origin}/bibliotech/api`;
+  }
+  
+  // If "/bibliotech" isn't in the path (like in Docker), just use /api
+  return `${origin}/api`;
+};
+
+export const API_BASE = getBaseUrl();

--- a/public/js/pages/auth.js
+++ b/public/js/pages/auth.js
@@ -43,7 +43,7 @@ if (loginForm) {
     try {
       const response = await login(email, senha);
       if (response.status === "success") {
-        window.location.href = "../../../bibliotech/view/home.html";
+        window.location.href = "home.html";
       } else {
         errorMessage.textContent = "Email ou senha incorretos. Tente novamente.";
         errorMessage.style.display = "block";
@@ -85,7 +85,7 @@ if (cadastroForm) {
     try {
       const response = await cadastrarUsuario(nome, email, senha);
       if (response.status === "success") {
-        window.location.href = "../../../bibliotech/view/login.html?cadastro=success";
+        window.location.href = "login.html?cadastro=success";
       } else {
         errorMessage.textContent = response.message;
         errorMessage.style.display = "block";

--- a/public/js/pages/livro.js
+++ b/public/js/pages/livro.js
@@ -196,7 +196,7 @@ function adicionarEventosTabela() {
     button.addEventListener("click", (e) => {
       const row = e.target.closest("tr");
       const bookId = row.querySelector("td").textContent.trim();
-      window.location.href = `/bibliotech/view/detalhes-livro.html?id=${bookId}`;
+      window.location.href = `detalhes-livro.html?id=${bookId}`;
     });
   });
 }


### PR DESCRIPTION
This pull request introduces several updates to improve the project’s configuration, dynamic URL handling, and frontend navigation. Key changes include adding Docker and Apache configurations, dynamically determining API base URLs, and simplifying frontend navigation paths.

### Configuration Updates:
* [`.dockerignore`](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R1-R9): Added common development files and directories to the `.dockerignore` file to prevent them from being included in Docker builds.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R54): Created a Dockerfile to set up a PHP 8.2 environment with Apache, necessary PHP extensions, and Apache configurations for clean URLs and default routing.
* [`.htaccess`](diffhunk://#diff-270939b4fba4be968ab78e23dc0207eb893744491980a25c99a27c809a82ddabR1-R31): Added rules for handling HTML files, root path redirection, and security measures to deny access to `.htaccess` itself.

### Dynamic URL Handling:
* [`public/js/config.js`](diffhunk://#diff-d3b65d7f5a032b219494d48abe03100240e8518a570d29ce0dd3d19b1076ed55L1-R18): Updated the `API_BASE` constant to dynamically determine the base URL based on the current location, ensuring compatibility with different environments (e.g., local or Docker).

### Frontend Navigation Simplification:
* [`public/js/pages/auth.js`](diffhunk://#diff-7cf8af127eda20b2091805382677a68f392ff397246cb009fa6baf560d8a85daL46-R46): Simplified navigation paths for login and registration success redirects by removing redundant directory references. [[1]](diffhunk://#diff-7cf8af127eda20b2091805382677a68f392ff397246cb009fa6baf560d8a85daL46-R46) [[2]](diffhunk://#diff-7cf8af127eda20b2091805382677a68f392ff397246cb009fa6baf560d8a85daL88-R88)
* [`public/js/pages/livro.js`](diffhunk://#diff-2415c2a02c3cb2d2a6c530625ebd5911c666b113754864a5567ae770efa69bcdL199-R199): Updated the book details navigation path to remove redundant `/bibliotech/view/` references.